### PR TITLE
Update README with instructions for compiling on Linux

### DIFF
--- a/strangemood/README.md
+++ b/strangemood/README.md
@@ -3,6 +3,8 @@
 ### Environment Setup
 1. Install Rust from https://rustup.rs/
 2. Install Solana from https://docs.solana.com/cli/install-solana-cli-tools#use-solanas-install-tool
+3. Ensure that libssl is installed: `sudo apt install libssl-dev` (or `brew install openssl` on macOS)
+4. Ensure libudev is installed: `sudo apt install libudev-dev`
 
 ### Build and test for program compiled natively
 ```


### PR DESCRIPTION
Cargo complained about missing libudev and libssl when compiling on Ubuntu 20.04 LTS in WSL2. I've updated the README with the commands I used to fix it.