### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,5 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Setup environment
+      run: |
+        sudo apt update \
+        sudo apt install libudev-dev 
     - name: Run tests
       run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup environment
       run: |
-        sudo apt update \
+        sudo apt update &&
         sudo apt install libudev-dev 
     - name: Run tests
       run: cargo test --verbose


### PR DESCRIPTION
The workflow now installs the missing  `libudev-dev` package via apt before running the tests.

It won't fail now! 😄 